### PR TITLE
Fix paginator (collapse long list of buttons.)

### DIFF
--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -77,7 +77,7 @@ func Test_SelectLabel(t *testing.T) {
 	r := require.New(t)
 	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
 	l := f.SelectTag("Name", tags.Options{"label": "Custom"})
-	r.Equal(`<div class="form-group"><label>Custom</label><select class=" form-control" id="-Name" name="Name" /></div>`, l.String())
+	r.Equal(`<div class="form-group"><label>Custom</label><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
 }
 
 func Test_RadioButton(t *testing.T) {

--- a/form/form_for_test.go
+++ b/form/form_for_test.go
@@ -21,7 +21,7 @@ func Test_NewFormFor(t *testing.T) {
 		"action": "/users/1",
 	})
 	r.Equal("form", f.Name)
-	r.Equal(`<form action="/users/1" id="talk-form" method="POST" />`, f.String())
+	r.Equal(`<form action="/users/1" id="talk-form" method="POST"></form>`, f.String())
 }
 
 func Test_FormFor_InputValue(t *testing.T) {

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -15,7 +15,7 @@ func Test_NewForm(t *testing.T) {
 		"action": "/users/1",
 	})
 	r.Equal("form", f.Name)
-	r.Equal(`<form action="/users/1" method="POST" />`, f.String())
+	r.Equal(`<form action="/users/1" method="POST"></form>`, f.String())
 }
 
 func Test_NewForm_With_AuthenticityToken(t *testing.T) {

--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -12,7 +12,7 @@ func Test_SelectTag(t *testing.T) {
 	r := require.New(t)
 	f := form.New(tags.Options{})
 	s := f.SelectTag(tags.Options{})
-	r.Equal(`<select />`, s.String())
+	r.Equal(`<select></select>`, s.String())
 }
 
 func Test_SelectTag_WithSelectOptions(t *testing.T) {

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -49,3 +49,59 @@ func Test_Pagination_Page3(t *testing.T) {
 
 	r.Equal(template.HTML("<ul class=\" pagination\"><li><a href=\"/foo?page=2\">&laquo;</a></li><li><a href=\"/foo?page=1\">1</a></li><li><a href=\"/foo?page=2\">2</a></li><li class=\"active\"><a href=\"/foo?page=3\">3</a></li><li class=\"disabled\"><span>&raquo;</span></li></ul>"), tag.HTML())
 }
+
+func Test_Pagination_LongPageStart(t *testing.T) {
+	r := require.New(t)
+
+	tag, err := Pagination(&pop.Paginator{
+		Page:       1,
+		TotalPages: 29,
+	}, Options{
+		"path": "/foo",
+	})
+	r.NoError(err)
+
+	r.Equal(template.HTML(`<ul class=" pagination"><li class="disabled"><span>&laquo;</span></li><li class="active"><a href="/foo?page=1">1</a></li><li><a href="/foo?page=2">2</a></li><li><a href="/foo?page=3">3</a></li><li><a href="/foo?page=4">4</a></li><li><a href="/foo?page=5">5</a></li><li><a href="/foo?page=6">6</a></li><li><a href="/foo?page=7">7</a></li><li><a href="/foo?page=8">8</a></li><li><a href="/foo?page=9">9</a></li><li class="disabled"><a>...</a></li><li><a href="/foo?page=29">29</a></li><li><a href="/foo?page=2">&raquo;</a></li></ul>`), tag.HTML())
+}
+
+func Test_Pagination_LongPageStartPoint1(t *testing.T) {
+	r := require.New(t)
+
+	tag, err := Pagination(&pop.Paginator{
+		Page:       6,
+		TotalPages: 29,
+	}, Options{
+		"path": "/foo",
+	})
+	r.NoError(err)
+
+	r.Equal(template.HTML(`<ul class=" pagination"><li><a href="/foo?page=5">&laquo;</a></li><li><a href="/foo?page=1">1</a></li><li><a href="/foo?page=2">2</a></li><li><a href="/foo?page=3">3</a></li><li><a href="/foo?page=4">4</a></li><li><a href="/foo?page=5">5</a></li><li class="active"><a href="/foo?page=6">6</a></li><li><a href="/foo?page=7">7</a></li><li><a href="/foo?page=8">8</a></li><li><a href="/foo?page=9">9</a></li><li class="disabled"><a>...</a></li><li><a href="/foo?page=29">29</a></li><li><a href="/foo?page=7">&raquo;</a></li></ul>`), tag.HTML())
+}
+
+func Test_Pagination_LongPagePoint2(t *testing.T) {
+	r := require.New(t)
+
+	tag, err := Pagination(&pop.Paginator{
+		Page:       23,
+		TotalPages: 29,
+	}, Options{
+		"path": "/foo",
+	})
+	r.NoError(err)
+
+	r.Equal(template.HTML(`<ul class=" pagination"><li><a href="/foo?page=22">&laquo;</a></li><li><a href="/foo?page=1">1</a></li><li class="disabled"><a>...</a></li><li><a href="/foo?page=20">20</a></li><li><a href="/foo?page=21">21</a></li><li><a href="/foo?page=22">22</a></li><li class="active"><a href="/foo?page=23">23</a></li><li><a href="/foo?page=24">24</a></li><li><a href="/foo?page=25">25</a></li><li><a href="/foo?page=26">26</a></li><li class="disabled"><a>...</a></li><li><a href="/foo?page=29">29</a></li><li><a href="/foo?page=24">&raquo;</a></li></ul>`), tag.HTML())
+}
+
+func Test_Pagination_LongPageEnd(t *testing.T) {
+	r := require.New(t)
+
+	tag, err := Pagination(&pop.Paginator{
+		Page:       24,
+		TotalPages: 29,
+	}, Options{
+		"path": "/foo",
+	})
+	r.NoError(err)
+
+	r.Equal(template.HTML(`<ul class=" pagination"><li><a href="/foo?page=23">&laquo;</a></li><li><a href="/foo?page=1">1</a></li><li class="disabled"><a>...</a></li><li><a href="/foo?page=21">21</a></li><li><a href="/foo?page=22">22</a></li><li><a href="/foo?page=23">23</a></li><li class="active"><a href="/foo?page=24">24</a></li><li><a href="/foo?page=25">25</a></li><li><a href="/foo?page=26">26</a></li><li><a href="/foo?page=27">27</a></li><li><a href="/foo?page=28">28</a></li><li><a href="/foo?page=29">29</a></li><li><a href="/foo?page=25">&raquo;</a></li></ul>`), tag.HTML())
+}

--- a/tag.go
+++ b/tag.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"html/template"
 	"reflect"
+	"strings"
 	"time"
 )
+
+// void tags https://www.w3.org/TR/html5/syntax.html#void-elements
+const voidTags = " area base br col embed hr img input keygen link meta param source track wbr "
 
 type Body interface{}
 
@@ -69,6 +73,12 @@ func (t Tag) String() string {
 			}
 		}
 		bb.WriteString("</")
+		bb.WriteString(t.Name)
+		bb.WriteString(">")
+		return bb.String()
+	}
+	if !strings.Contains(voidTags, " "+t.Name+" ") {
+		bb.WriteString("></")
 		bb.WriteString(t.Name)
 		bb.WriteString(">")
 		return bb.String()

--- a/tag_test.go
+++ b/tag_test.go
@@ -17,9 +17,16 @@ func Test_Tag(t *testing.T) {
 
 func Test_Tag_WithName(t *testing.T) {
 	r := require.New(t)
+	tag := tags.New("br", tags.Options{})
+	r.Equal("br", tag.Name)
+	r.Equal(`<br />`, tag.String())
+}
+
+func Test_Tag_NonVoid(t *testing.T) {
+	r := require.New(t)
 	tag := tags.New("div", tags.Options{})
 	r.Equal("div", tag.Name)
-	r.Equal(`<div />`, tag.String())
+	r.Equal(`<div></div>`, tag.String())
 }
 
 func Test_Tag_WithValue(t *testing.T) {


### PR DESCRIPTION
Hi, I read recently added CONTRIBUTE.md for buffalo but I made a PR without discussion. sorry.

The main part of this PR is just collapse long list of buttons when the `TotalPages` are bigger.
I introduced an option named `wingLength` which means button count of left/right side of the center button (`Page`). for example, if the `TotalPages` is 30, the current `Page` is 17, and `wingLength` is 5, then only `1, ..., 14, 15, 16, [17], 18, 19, 20, ..., 30` will be shown. users can increase the option but IMHO, especially for mobile pages, this length is somewhat reasonable.

Second part of this PR is fix for empty tag. when paginator runs, if the `TotalPages` is 1, then it just returns empty `div` but the form is `<div />`, which can be interpreted as just open tag. (so following divs are working incorrectly. so I added some codes for avoiding self-closing for non-void tags.

Please consider this PR.
Thanks.