### PR TITLE
SelectTag allow_blank works with SelectOptions

### DIFF
--- a/form/select_tag.go
+++ b/form/select_tag.go
@@ -53,21 +53,22 @@ func parseSelectOptions(opts tags.Options) SelectOptions {
 	sopts := opts["options"]
 	delete(opts, "options")
 
-	if x, ok := sopts.(SelectOptions); ok {
-		return x
-	}
-
-	rv := reflect.ValueOf(sopts)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-	}
-
 	so := SelectOptions{}
 	if aw, ok := allowBlank.(bool); ok && aw {
 		so = append(so, SelectOption{
 			Value: "",
 			Label: "",
 		})
+	}
+
+	if x, ok := sopts.(SelectOptions); ok {
+		x = append(so, x...) // prepend blank SelectOption if present
+		return x
+	}
+
+	rv := reflect.ValueOf(sopts)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
 	}
 
 	switch rv.Kind() {

--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -144,6 +144,45 @@ func Test_SelectTag_WithUUID_Selected_withBlank(t *testing.T) {
 		"allow_blank": true,
 	})
 	s := st.String()
+	r.Contains(s, `<option value=""></option>`)
+	r.Contains(s, fmt.Sprintf(`<option value="%s">John</option>`, jid))
+	r.Contains(s, fmt.Sprintf(`<option value="%s" selected>Peter</option>`, pid))
+}
+
+func Test_SelectTag_WithUUID_Selected_withBlankSelectOptions(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	jid := uuid.NewV4()
+	pid := uuid.NewV4()
+	st := f.SelectTag(tags.Options{
+		"options": form.SelectOptions{
+			form.SelectOption{Label: "John", Value: jid},
+			form.SelectOption{Label: "Peter", Value: pid},
+		},
+		"value":       pid,
+		"allow_blank": true,
+	})
+	s := st.String()
+	r.Contains(s, `<option value=""></option>`)
+	r.Contains(s, fmt.Sprintf(`<option value="%s">John</option>`, jid))
+	r.Contains(s, fmt.Sprintf(`<option value="%s" selected>Peter</option>`, pid))
+}
+
+func Test_SelectTag_WithUUID_Selected_withoutBlankSelectOptions(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	jid := uuid.NewV4()
+	pid := uuid.NewV4()
+	st := f.SelectTag(tags.Options{
+		"options": form.SelectOptions{
+			form.SelectOption{Label: "John", Value: jid},
+			form.SelectOption{Label: "Peter", Value: pid},
+		},
+		"value":       pid,
+		"allow_blank": false,
+	})
+	s := st.String()
+	r.NotContains(s, `<option value=""></option>`)
 	r.Contains(s, fmt.Sprintf(`<option value="%s">John</option>`, jid))
 	r.Contains(s, fmt.Sprintf(`<option value="%s" selected>Peter</option>`, pid))
 }


### PR DESCRIPTION
When `SelectTag` receives `SelectOptions`, the method exits before applying the `allow_blank` opt. This PR reorders the logic slightly and adds tests.