### PR TITLE
Allow SelectTag to use a Selectable value as selected value

### DIFF
--- a/form/select_tag.go
+++ b/form/select_tag.go
@@ -27,7 +27,7 @@ func (s SelectTag) HTML() template.HTML {
 
 func NewSelectTag(opts tags.Options) *SelectTag {
 	so := parseSelectOptions(opts)
-	selected := opts["value"]
+	selected := parseSelectValue(opts["value"])
 	delete(opts, "value")
 
 	st := &SelectTag{
@@ -96,4 +96,21 @@ func parseSelectOptions(opts tags.Options) SelectOptions {
 		}
 	}
 	return so
+}
+
+func parseSelectValue(x interface{}) interface{} {
+	rv := reflect.ValueOf(x)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+
+	if rv.Kind() == reflect.Struct {
+		// Extract value if val implements Selectable
+		selectableType := reflect.TypeOf((*Selectable)(nil)).Elem()
+		if rv.Type().Implements(selectableType) {
+			return x.(Selectable).SelectValue()
+		}
+	}
+
+	return x
 }

--- a/form/select_tag.go
+++ b/form/select_tag.go
@@ -27,7 +27,11 @@ func (s SelectTag) HTML() template.HTML {
 
 func NewSelectTag(opts tags.Options) *SelectTag {
 	so := parseSelectOptions(opts)
-	selected := parseSelectValue(opts["value"])
+	selected := opts["value"]
+
+	if s, ok := selected.(Selectable); ok {
+		selected = s.SelectValue()
+	}
 	delete(opts, "value")
 
 	st := &SelectTag{
@@ -96,21 +100,4 @@ func parseSelectOptions(opts tags.Options) SelectOptions {
 		}
 	}
 	return so
-}
-
-func parseSelectValue(x interface{}) interface{} {
-	rv := reflect.ValueOf(x)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-	}
-
-	if rv.Kind() == reflect.Struct {
-		// Extract value if val implements Selectable
-		selectableType := reflect.TypeOf((*Selectable)(nil)).Elem()
-		if rv.Type().Implements(selectableType) {
-			return x.(Selectable).SelectValue()
-		}
-	}
-
-	return x
 }

--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -113,6 +113,21 @@ func Test_SelectTag_WithSlice_Selectable(t *testing.T) {
 	r.Contains(s, `<option value="2">Peter</option>`)
 }
 
+func Test_SelectTag_WithSlice_Selectable_Interface(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"options": []SelectableModel{
+			{"John", "1"},
+			{"Peter", "2"},
+		},
+		"value": SelectableModel{"John", "1"},
+	})
+	s := st.String()
+	r.Contains(s, `<option value="1" selected>John</option>`)
+	r.Contains(s, `<option value="2">Peter</option>`)
+}
+
 func Test_SelectTag_WithUUID_Selected(t *testing.T) {
 	r := require.New(t)
 	f := form.New(tags.Options{})


### PR DESCRIPTION
Given a SelectTag:

```erb
<%= f.SelectTag({name: "Group", value: user.Group, options: groupsList}) %>
```

This PR allows `user.Group` to be a struct, which implements the Selectable interface. It will use the `SelectValue()` as the selected value, just like the `options` attribute does.