### PR TITLE
Implements select multiple support

### DIFF
--- a/form/select_options.go
+++ b/form/select_options.go
@@ -5,21 +5,21 @@ import (
 	"html/template"
 )
 
+// SelectOption describes a HTML <select> tag <option> meta data.
 type SelectOption struct {
-	Value         interface{}
-	Label         interface{}
-	SelectedValue interface{}
+	Value    interface{}
+	Label    interface{}
+	Selected bool
 }
 
 func (s SelectOption) String() string {
 	v := template.HTMLEscaper(s.Value)
-	sv := template.HTMLEscaper(s.SelectedValue)
 	l := template.HTMLEscaper(s.Label)
 	bb := &bytes.Buffer{}
 	bb.WriteString(`<option value="`)
 	bb.WriteString(v)
 	bb.WriteString(`"`)
-	if v == sv {
+	if s.Selected {
 		bb.WriteString(` selected`)
 	}
 	bb.WriteString(`>`)
@@ -28,4 +28,5 @@ func (s SelectOption) String() string {
 	return bb.String()
 }
 
+// SelectOptions is a slice of SelectOption
 type SelectOptions []SelectOption

--- a/form/select_options_test.go
+++ b/form/select_options_test.go
@@ -19,9 +19,9 @@ func Test_SelectionOption_String(t *testing.T) {
 func Test_SelectionOption_Selected_String(t *testing.T) {
 	r := require.New(t)
 	so := form.SelectOption{
-		Value:         1,
-		Label:         "one",
-		SelectedValue: "1",
+		Value:    1,
+		Label:    "one",
+		Selected: true,
 	}
 	r.Equal(`<option value="1" selected>one</option>`, so.String())
 }

--- a/form/select_tag.go
+++ b/form/select_tag.go
@@ -7,41 +7,79 @@ import (
 	"github.com/gobuffalo/tags"
 )
 
+// SelectTag describes a HTML <select> tag meta data.
 type SelectTag struct {
 	*tags.Tag
-	SelectedValue interface{}
-	SelectOptions SelectOptions
+	SelectedValue      interface{}
+	selectedValueCache map[interface{}]struct{}
+	SelectOptions      SelectOptions
 }
 
 func (s SelectTag) String() string {
 	for _, x := range s.SelectOptions {
-		x.SelectedValue = s.SelectedValue
+		if _, ok := s.selectedValueCache[template.HTMLEscaper(x.Value)]; ok {
+			x.Selected = true
+		}
 		s.Append(x.String())
 	}
 	return s.Tag.String()
 }
 
+// HTML gives the HTML template representation for the select tag.
 func (s SelectTag) HTML() template.HTML {
 	return template.HTML(s.String())
 }
 
+// NewSelectTag constructs a new `<select>` tag.
 func NewSelectTag(opts tags.Options) *SelectTag {
 	so := parseSelectOptions(opts)
 	selected := opts["value"]
-
-	if s, ok := selected.(Selectable); ok {
-		selected = s.SelectValue()
-	}
 	delete(opts, "value")
 
+	// Transform selected value(s) into an empty map with values as keys
+	// (faster lookup than slice / array)
+	selectedMap := make(map[interface{}]struct{})
+
+	multiple, ok := opts["multiple"].(bool)
+	if multiple && ok {
+		// Set nil to use the empty attribute notation
+		opts["multiple"] = nil
+
+		rv := reflect.ValueOf(selected)
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
+		if rv.Kind() == reflect.Array || rv.Kind() == reflect.Slice {
+			for i := 0; i < rv.Len(); i++ {
+				x := rv.Index(i).Interface()
+				if s, ok := x.(Selectable); ok {
+					// Use Selectable value as the selected value
+					x = s.SelectValue()
+				}
+				selectedMap[template.HTMLEscaper(x)] = struct{}{}
+			}
+		} else {
+			// Set unique value as a map key
+			selectedMap[template.HTMLEscaper(selected)] = struct{}{}
+		}
+	} else {
+		if s, ok := selected.(Selectable); ok {
+			selected = s.SelectValue()
+		}
+		// Set unique value as a map key
+		selectedMap[template.HTMLEscaper(selected)] = struct{}{}
+	}
+
 	st := &SelectTag{
-		Tag:           tags.New("select", opts),
-		SelectOptions: so,
-		SelectedValue: selected,
+		Tag:                tags.New("select", opts),
+		SelectOptions:      so,
+		SelectedValue:      selected,
+		selectedValueCache: selectedMap,
 	}
 	return st
 }
 
+// SelectTag constructs a new `<select>` tag from a form.
 func (f Form) SelectTag(opts tags.Options) *SelectTag {
 	return NewSelectTag(opts)
 }

--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -202,6 +202,70 @@ func Test_SelectTag_WithUUID_Selected_withoutBlankSelectOptions(t *testing.T) {
 	r.Contains(s, fmt.Sprintf(`<option value="%s" selected>Peter</option>`, pid))
 }
 
+func Test_SelectTag_Multiple(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"multiple": true,
+		"options":  []string{"one", "two"},
+	})
+	s := st.String()
+	r.Contains(s, `<select multiple>`)
+	r.Contains(s, `<option value="one">one</option>`)
+	r.Contains(s, `<option value="two">two</option>`)
+}
+
+func Test_SelectTag_Multiple_SelectOne(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"multiple": true,
+		"options":  []string{"one", "two"},
+		"value":    "one",
+	})
+	s := st.String()
+	r.Contains(s, `<select multiple>`)
+	r.Contains(s, `<option value="one" selected>one</option>`)
+	r.Contains(s, `<option value="two">two</option>`)
+}
+
+func Test_SelectTag_Multiple_SelectMultiple(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"multiple": true,
+		"options":  []string{"one", "two", "three"},
+		"value":    []string{"one", "two"},
+	})
+	s := st.String()
+	r.Contains(s, `<select multiple>`)
+	r.Contains(s, `<option value="one" selected>one</option>`)
+	r.Contains(s, `<option value="two" selected>two</option>`)
+	r.Contains(s, `<option value="three">three</option>`)
+}
+
+func Test_SelectTag_Multiple_SelectMultiple_Selectable_Interface(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"multiple": true,
+		"options": []SelectableModel{
+			{"John", "1"},
+			{"Peter", "2"},
+			{"Mark", "3"},
+		},
+		"value": []SelectableModel{
+			{"John", "1"},
+			{"Peter", "2"},
+		},
+	})
+	s := st.String()
+	r.Contains(s, `<select multiple>`)
+	r.Contains(s, `<option value="1" selected>John</option>`)
+	r.Contains(s, `<option value="2" selected>Peter</option>`)
+	r.Contains(s, `<option value="3">Mark</option>`)
+}
+
 type SelectableModel struct {
 	Name string
 	ID   string

--- a/options.go
+++ b/options.go
@@ -15,8 +15,14 @@ func (o Options) String() string {
 	var tmp = make([]string, 2)
 	for k, v := range o {
 		tmp[0] = template.HTMLEscaper(k)
-		tmp[1] = fmt.Sprintf("\"%s\"", template.HTMLEscaper(v))
-		out = append(out, strings.Join(tmp, "="))
+		if v != nil {
+			tmp[1] = fmt.Sprintf("\"%s\"", template.HTMLEscaper(v))
+			out = append(out, strings.Join(tmp, "="))
+		} else {
+			// nil attribute value is interpreted as empty attribute notation
+			// https://www.w3.org/TR/html5/syntax.html#elements-attributes
+			out = append(out, tmp[0])
+		}
 	}
 	sort.Strings(out)
 	return strings.Join(out, " ")

--- a/options_test.go
+++ b/options_test.go
@@ -26,3 +26,13 @@ func Test_Options_String_Escaped(t *testing.T) {
 	s := o.String()
 	r.Equal(`&lt;b&gt;="&lt;p&gt;"`, s)
 }
+
+func Test_Options_String_Empty_Attribute(t *testing.T) {
+	r := require.New(t)
+	o := tags.Options{
+		"value":   "Mark",
+		"checked": nil,
+	}
+	s := o.String()
+	r.Equal(`checked value="Mark"`, s)
+}


### PR DESCRIPTION
Allows `SelectTag` to support multiple selectable values.
See #43.