### PR TITLE
Adding before and after tags

### DIFF
--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -80,6 +80,22 @@ func Test_SelectLabel(t *testing.T) {
 	r.Equal(`<div class="form-group"><label>Custom</label><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
 }
 
+func Test_Select_With_BeforeTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
+	b := `<span>Test</span>`
+	l := f.SelectTag("Name", tags.Options{"before_tag": b})
+	r.Equal(`<div class="form-group"><label>Name</label><span>Test</span><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
+}
+
+func Test_Select_With_AfterTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
+	b := `<button type="button">Button Name</button>`
+	l := f.SelectTag("Name", tags.Options{"after_tag": b})
+	r.Equal(`<div class="form-group"><label>Name</label><select class=" form-control" id="-Name" name="Name"></select><button type="button">Button Name</button></div>`, l.String())
+}
+
 func Test_RadioButton(t *testing.T) {
 	r := require.New(t)
 	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})

--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -80,19 +80,46 @@ func Test_SelectLabel(t *testing.T) {
 	r.Equal(`<div class="form-group"><label>Custom</label><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
 }
 
-func Test_Select_With_BeforeTag_Opt(t *testing.T) {
+func Test_Select_With_String_As_BeforeTag_Opt(t *testing.T) {
 	r := require.New(t)
 	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
-	b := `<span>Test</span>`
-	l := f.SelectTag("Name", tags.Options{"before_tag": b})
+
+	s := `<span>Test</span>`
+	l := f.SelectTag("Name", tags.Options{"before_tag": s})
+
 	r.Equal(`<div class="form-group"><label>Name</label><span>Test</span><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
 }
 
-func Test_Select_With_AfterTag_Opt(t *testing.T) {
+func Test_Select_With_Nested_Tag_As_BeforeTag_Opt(t *testing.T) {
 	r := require.New(t)
 	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
+
+	s := tags.New("span", tags.Options{"body": "Test"})
+	l := f.SelectTag("Name", tags.Options{"before_tag": s})
+
+	r.Equal(`<div class="form-group"><label>Name</label><span>Test</span><select class=" form-control" id="-Name" name="Name"></select></div>`, l.String())
+}
+
+func Test_Select_With_String_As_AfterTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
+
 	b := `<button type="button">Button Name</button>`
 	l := f.SelectTag("Name", tags.Options{"after_tag": b})
+
+	r.Equal(`<div class="form-group"><label>Name</label><select class=" form-control" id="-Name" name="Name"></select><button type="button">Button Name</button></div>`, l.String())
+}
+
+func Test_Select_With_Nested_Tag_As_AfterTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := bootstrap.NewFormFor(struct{ Name string }{}, tags.Options{})
+
+	b := tags.New("button", tags.Options{
+		"body": "Button Name",
+		"type": "button",
+	})
+	l := f.SelectTag("Name", tags.Options{"after_tag": b})
+
 	r.Equal(`<div class="form-group"><label>Name</label><select class=" form-control" id="-Name" name="Name"></select><button type="button">Button Name</button></div>`, l.String())
 }
 

--- a/form/form_for_test.go
+++ b/form/form_for_test.go
@@ -35,6 +35,26 @@ func Test_FormFor_InputValue(t *testing.T) {
 	r.Equal(`<input id="talk-Name" name="Name" type="text" value="Something" />`, l.String())
 }
 
+func Test_FormFor_Input_BeforeTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := form.NewFormFor(Talk{}, tags.Options{})
+
+	s := `<span>Content</span>`
+	l := f.InputTag("Test", tags.Options{"before_tag": s})
+
+	r.Equal(`<span>Content</span><input id="talk-Test" name="Test" type="text" value="" />`, l.String())
+}
+
+func Test_FormFor_Input_AfterTag_Opt(t *testing.T) {
+	r := require.New(t)
+	f := form.NewFormFor(Talk{}, tags.Options{})
+
+	b := `<button>Button</button>`
+	l := f.InputTag("Test", tags.Options{"after_tag": b})
+
+	r.Equal(`<input id="talk-Test" name="Test" type="text" value="" /><button>Button</button>`, l.String())
+}
+
 func Test_FormFor_File(t *testing.T) {
 	r := require.New(t)
 	f := form.NewFormFor(Talk{}, tags.Options{

--- a/tag.go
+++ b/tag.go
@@ -76,7 +76,6 @@ func (t Tag) String() string {
 		bb.WriteString(parseTagEmbed(bt))
 	}
 
-	// Function for opening tag BEGIN
 	bb.WriteString("<")
 	bb.WriteString(t.Name)
 	if len(t.Options) > 0 {
@@ -91,7 +90,7 @@ func (t Tag) String() string {
 	}
 	if len(t.Body) > 0 {
 		bb.WriteString(">")
-		// Function for opening tag END - if body
+
 		for _, b := range t.Body {
 			bb.WriteString(parseTagEmbed(b))
 		}
@@ -107,7 +106,6 @@ func (t Tag) String() string {
 		return bb.String()
 	}
 	if !strings.Contains(voidTags, " "+t.Name+" ") {
-		// Function for opening tag END - if no body
 		bb.WriteString("></")
 		bb.WriteString(t.Name)
 		bb.WriteString(">")

--- a/tag.go
+++ b/tag.go
@@ -51,31 +51,29 @@ type htmler interface {
 	HTML() template.HTML
 }
 
-func parseTagEmbed(b interface{}, bb *bytes.Buffer) {
+func parseTagEmbed(b interface{}) string {
 	switch tb := b.(type) {
 	case htmler:
-		bb.Write([]byte(tb.HTML()))
+		return fmt.Sprint(tb.HTML())
 	case fmt.Stringer:
-		bb.WriteString(tb.String())
+		return tb.String()
 	case interfacer:
 		val := tb.Interface()
 		if tb.Interface() == nil {
 			val = ""
 		}
 
-		bb.WriteString(fmt.Sprint(val))
+		return fmt.Sprint(val)
 	default:
-		bb.WriteString(fmt.Sprint(tb))
+		return fmt.Sprint(tb)
 	}
 }
 
 func (t Tag) String() string {
 	bb := &bytes.Buffer{}
 
-	if len(t.BeforeTag) > 0 {
-		for _, bt := range t.BeforeTag {
-			parseTagEmbed(bt, bb)
-		}
+	for _, bt := range t.BeforeTag {
+		bb.WriteString(parseTagEmbed(bt))
 	}
 
 	// Function for opening tag BEGIN
@@ -95,17 +93,15 @@ func (t Tag) String() string {
 		bb.WriteString(">")
 		// Function for opening tag END - if body
 		for _, b := range t.Body {
-			parseTagEmbed(b, bb)
+			bb.WriteString(parseTagEmbed(b))
 		}
 
 		bb.WriteString("</")
 		bb.WriteString(t.Name)
 		bb.WriteString(">")
 
-		if len(t.AfterTag) > 0 {
-			for _, at := range t.AfterTag {
-				parseTagEmbed(at, bb)
-			}
+		for _, at := range t.AfterTag {
+			bb.WriteString(parseTagEmbed(at))
 		}
 
 		return bb.String()
@@ -116,20 +112,16 @@ func (t Tag) String() string {
 		bb.WriteString(t.Name)
 		bb.WriteString(">")
 
-		if len(t.AfterTag) > 0 {
-			for _, at := range t.AfterTag {
-				parseTagEmbed(at, bb)
-			}
+		for _, at := range t.AfterTag {
+			bb.WriteString(parseTagEmbed(at))
 		}
 
 		return bb.String()
 	}
 	bb.WriteString(" />")
 
-	if len(t.AfterTag) > 0 {
-		for _, at := range t.AfterTag {
-			parseTagEmbed(at, bb)
-		}
+	for _, at := range t.AfterTag {
+		bb.WriteString(parseTagEmbed(at))
 	}
 
 	return bb.String()

--- a/tag.go
+++ b/tag.go
@@ -45,6 +45,16 @@ type htmler interface {
 
 func (t Tag) String() string {
 	bb := &bytes.Buffer{}
+
+	if bt := t.Options["before_tag"]; bt != nil {
+		bb.WriteString(bt.(string))
+		delete(t.Options, "before_tag")
+	}
+
+	at := t.Options["after_tag"]
+	if at != nil {
+		delete(t.Options, "after_tag")
+	}
 	bb.WriteString("<")
 	bb.WriteString(t.Name)
 	if len(t.Options) > 0 {
@@ -79,15 +89,25 @@ func (t Tag) String() string {
 		bb.WriteString("</")
 		bb.WriteString(t.Name)
 		bb.WriteString(">")
+		if at != nil {
+			bb.WriteString(at.(string))
+		}
 		return bb.String()
 	}
 	if !strings.Contains(voidTags, " "+t.Name+" ") {
 		bb.WriteString("></")
 		bb.WriteString(t.Name)
 		bb.WriteString(">")
+		if at != nil {
+			bb.WriteString(at.(string))
+		}
 		return bb.String()
 	}
 	bb.WriteString(" />")
+
+	if at != nil {
+		bb.WriteString(at.(string))
+	}
 	return bb.String()
 }
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -67,6 +67,30 @@ func Test_Tag_WithBody(t *testing.T) {
 	r.Nil(tag.Options["body"])
 }
 
+func Test_Tag_WithBody_And_BeforeTag(t *testing.T) {
+	r := require.New(t)
+	s := `<span>Test</span>`
+
+	tag := tags.New("div", tags.Options{
+		"body":       "hi there!",
+		"before_tag": s,
+	})
+	r.Equal(`<span>Test</span><div>hi there!</div>`, tag.String())
+	r.Nil(tag.Options["body"])
+}
+
+func Test_Tag_WithBody_And_AfterTag(t *testing.T) {
+	r := require.New(t)
+	s := `<span>Test</span>`
+
+	tag := tags.New("div", tags.Options{
+		"body":      "hi there!",
+		"after_tag": s,
+	})
+	r.Equal(`<div>hi there!</div><span>Test</span>`, tag.String())
+	r.Nil(tag.Options["body"])
+}
+
 func Test_Tag_String(t *testing.T) {
 	r := require.New(t)
 
@@ -95,4 +119,26 @@ func Test_Tag_String_SubTag(t *testing.T) {
 		}),
 	})
 	r.Equal(`<div><p>hi!</p></div>`, tag.String())
+}
+
+func Test_Tag_String_With_BeforeTag_Opt(t *testing.T) {
+	r := require.New(t)
+	s := `<span>Test</span>`
+
+	tag := tags.New("div", tags.Options{
+		"before_tag": s,
+	})
+
+	r.Equal(`<span>Test</span><div></div>`, tag.String())
+}
+
+func Test_Tag_String_With_AfterTag_Opt(t *testing.T) {
+	r := require.New(t)
+	s := `<span>Test</span>`
+
+	tag := tags.New("div", tags.Options{
+		"after_tag": s,
+	})
+
+	r.Equal(`<div></div><span>Test</span>`, tag.String())
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -142,3 +142,21 @@ func Test_Tag_String_With_AfterTag_Opt(t *testing.T) {
 
 	r.Equal(`<div></div><span>Test</span>`, tag.String())
 }
+
+func Test_Tag_With_Another_Tag_As_BeforeTag(t *testing.T) {
+	r := require.New(t)
+	s := tags.New("span", tags.Options{"body": "Test"})
+
+	tag := tags.New("div", tags.Options{"before_tag": s})
+
+	r.Equal(`<span>Test</span><div></div>`, tag.String())
+}
+
+func Test_Tag_With_Another_Tag_As_AfterTag(t *testing.T) {
+	r := require.New(t)
+	s := tags.New("span", tags.Options{"body": "Test"})
+
+	tag := tags.New("div", tags.Options{"after_tag": s})
+
+	r.Equal(`<div></div><span>Test</span>`, tag.String())
+}


### PR DESCRIPTION
Adding an implementation of before/after_tag for the ability to specify a string or other tag within the `tags.Options{}` which will primarily help when using tags with bootstrap, as shown in the example.

Example:
```
<%= f.SelectTag("Sample", {options: samples, after_tag: "<button>Button</button>"}) %>
```

Output:
```
<div class="form-group">
    <select id="Sample" name="Sample">
        ...samples
    </select>
    <button>Button</button>
</div>
```

Looking for criticisms/critiques/notes...
