### PR TITLE
Commenting out warning messages

### DIFF
--- a/form/form_for.go
+++ b/form/form_for.go
@@ -127,7 +127,7 @@ func (f FormFor) addFormatTag(field string, opts tags.Options) {
 
 //RadioButton creates a radio button for a struct field
 func (f FormFor) RadioButton(field string, opts tags.Options) *tags.Tag {
-	log.Println("[Warning] RadioButton is deprecated and may be removed in the future, use RadioButtonTag instead")
+	// log.Println("[Warning] RadioButton is deprecated and may be removed in the future, use RadioButtonTag instead")
 	return f.RadioButton(field, opts)
 }
 

--- a/form/radio_button_tag.go
+++ b/form/radio_button_tag.go
@@ -3,7 +3,6 @@ package form
 import (
 	"fmt"
 	"html/template"
-	"log"
 	"strings"
 
 	"github.com/gobuffalo/tags"
@@ -11,7 +10,7 @@ import (
 
 //RadioButton creates a radio button for a form with the passed options
 func (f Form) RadioButton(opts tags.Options) *tags.Tag {
-	log.Println("[Warning] RadioButton is deprecated and may be removed in the future, use RadioButtonTag instead")
+	// log.Println("[Warning] RadioButton is deprecated and may be removed in the future, use RadioButtonTag instead")
 	return f.RadioButtonTag(opts)
 }
 

--- a/form/text_area_tag.go
+++ b/form/text_area_tag.go
@@ -1,14 +1,12 @@
 package form
 
 import (
-	"log"
-
 	"github.com/gobuffalo/tags"
 )
 
 //TextArea creates a textarea for a form with passed options
 func (f Form) TextArea(opts tags.Options) *tags.Tag {
-	log.Println("[Warning] TextArea is deprecated and may be removed in the future, use TextAreaTag instead")
+	// log.Println("[Warning] TextArea is deprecated and may be removed in the future, use TextAreaTag instead")
 	return f.TextAreaTag(opts)
 }
 


### PR DESCRIPTION
We're postposing deprecation notes for the next tags release because it would imply some changes in Buffalo, once we've covered those changes we can deprecate those methods without affecting users.