### PR TITLE
Use gobuffalo/flect instead of markbates/inflect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 sudo: false
+install: false
 
 matrix:
   include:
@@ -29,6 +30,6 @@ matrix:
     env:
       - GO111MODULE=on
 
-install: make deps
-
-script: make ci-test
+script:
+  - go get -v -t ./...
+  - go test -v  -timeout=5s -race ./...

--- a/form/bootstrap/common.go
+++ b/form/bootstrap/common.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/tags"
-	"github.com/markbates/inflect"
 )
 
 func buildOptions(opts tags.Options, err bool) {
@@ -43,7 +43,7 @@ func divWrapper(opts tags.Options, fn func(opts tags.Options) tags.Body) *tags.T
 	if opts["label"] == nil && opts["tags-field"] != nil {
 		if tf, ok := opts["tags-field"].(string); ok {
 			tf = strings.Join(strings.Split(tf, "."), " ")
-			opts["label"] = inflect.Titleize(tf)
+			opts["label"] = flect.Titleize(tf)
 		}
 	}
 

--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -22,7 +22,7 @@ func Test_InputFieldLabelWithAchronym(t *testing.T) {
 		"URL":            "URL",
 		"MyURL":          "My URL",
 		"SimpleURIAdded": "Simple URI Added",
-		"GaveAThing":     "Gave A Thing",
+		"GaveAnExample":  "Gave An Example",
 	}
 	r := require.New(t)
 	f := bootstrap.NewFormFor(struct{ URL string }{}, tags.Options{})

--- a/form/form_for.go
+++ b/form/form_for.go
@@ -9,15 +9,15 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/tags"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
-	"github.com/markbates/inflect"
 )
 
 var arrayFieldRegExp = regexp.MustCompile("^([A-Za-z0-9]+)\\[(\\d+)\\]$")
 
-//FormFor is a form made for a struct
+// FormFor is a form made for a struct
 type FormFor struct {
 	*Form
 	Model      interface{}
@@ -27,14 +27,14 @@ type FormFor struct {
 	Errors     *validate.Errors
 }
 
-//NewFormFor creates a new Formfor with passed options, it also creates the id of the form from the struct name and adds errors if present.
+// NewFormFor creates a new Formfor with passed options, it also creates the id of the form from the struct name and adds errors if present.
 func NewFormFor(model interface{}, opts tags.Options) *FormFor {
 	rv := reflect.ValueOf(model)
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
 	}
 	name := rv.Type().Name()
-	dashedName := inflect.Dasherize(name)
+	dashedName := flect.Dasherize(name)
 
 	if opts["id"] == nil {
 		opts["id"] = fmt.Sprintf("%s-form", dashedName)
@@ -72,33 +72,33 @@ func loadErrors(opts tags.Options) *validate.Errors {
 	return errors
 }
 
-//CheckboxTag creates a checkbox for a field on the form Struct
+// CheckboxTag creates a checkbox for a field on the form Struct
 func (f FormFor) CheckboxTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	return f.Form.CheckboxTag(opts)
 }
 
-//InputTag creates an input for a field on the form Struct
+// InputTag creates an input for a field on the form Struct
 func (f FormFor) InputTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	f.addFormatTag(field, opts)
 	return f.Form.InputTag(opts)
 }
 
-//HiddenTag adds a wrappter for input type hidden on the form
+// HiddenTag adds a wrappter for input type hidden on the form
 func (f FormFor) HiddenTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	return f.Form.HiddenTag(opts)
 }
 
-//FileTag creates a input[type=file] for a field name passed
+// FileTag creates a input[type=file] for a field name passed
 func (f FormFor) FileTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	f.addFormatTag(field, opts)
 	return f.Form.FileTag(opts)
 }
 
-//DateTimeTag creates a input[type=datetime-local] for a field name passed
+// DateTimeTag creates a input[type=datetime-local] for a field name passed
 func (f FormFor) DateTimeTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	f.addFormatTag(field, opts)
@@ -128,35 +128,35 @@ func (f FormFor) addFormatTag(field string, opts tags.Options) {
 	}
 }
 
-//RadioButton creates a radio button for a struct field
+// RadioButton creates a radio button for a struct field
 func (f FormFor) RadioButton(field string, opts tags.Options) *tags.Tag {
 	return f.RadioButtonTag(field, opts)
 }
 
-//RadioButtonTag creates a radio button for a struct field
+// RadioButtonTag creates a radio button for a struct field
 func (f FormFor) RadioButtonTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	return f.Form.RadioButtonTag(opts)
 }
 
-//SelectTag creates a select tag for a specified struct field and loads options from the options opject
+// SelectTag creates a select tag for a specified struct field and loads options from the options opject
 func (f FormFor) SelectTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	return f.Form.SelectTag(opts)
 }
 
-//TextArea creates text area for the specified struct field
+// TextArea creates text area for the specified struct field
 func (f FormFor) TextArea(field string, opts tags.Options) *tags.Tag {
 	return f.TextAreaTag(field, opts)
 }
 
-//TextAreaTag creates text area for the specified struct field
+// TextAreaTag creates text area for the specified struct field
 func (f FormFor) TextAreaTag(field string, opts tags.Options) *tags.Tag {
 	f.buildOptions(field, opts)
 	return f.Form.TextArea(opts)
 }
 
-//SubmitTag adds a submit button to the form
+// SubmitTag adds a submit button to the form
 func (f FormFor) SubmitTag(value string, opts tags.Options) *tags.Tag {
 	return f.Form.SubmitTag(value, opts)
 }

--- a/shoulders.md
+++ b/shoulders.md
@@ -9,6 +9,8 @@ Thank you to the following **GIANTS**:
 
 * [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
 
+* [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
+
 * [github.com/gobuffalo/uuid](https://godoc.org/github.com/gobuffalo/uuid)
 
 * [github.com/gobuffalo/validate](https://godoc.org/github.com/gobuffalo/validate)
@@ -18,8 +20,6 @@ Thank you to the following **GIANTS**:
 * [github.com/kr/pretty](https://godoc.org/github.com/kr/pretty)
 
 * [github.com/kr/text](https://godoc.org/github.com/kr/text)
-
-* [github.com/markbates/inflect](https://godoc.org/github.com/markbates/inflect)
 
 * [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
 


### PR DESCRIPTION
Currently, the tests are failing for label generation for `"GaveAThing"`. This was working with flect, as in this case it basically treated `A` as an acronym (multiple uppercase letters get split at the last one) and separated it from the rest (returning `"Gave A Thing"`). Inflect is handling this in a different way and treats it as `"Gave AThing"`.

I'm not sure which one is the expected result. I don't think the approach of flect is good (on the matter of how it's done), but on the other hand this is a breaking change and removes the ability of creating single char words in labels.

@markbates @paganotoni, what are your opinions on this?