### PR TITLE
Adding Select Tag Placeholder Option

### DIFF
--- a/form/select_options.go
+++ b/form/select_options.go
@@ -7,9 +7,10 @@ import (
 
 // SelectOption describes a HTML <select> tag <option> meta data.
 type SelectOption struct {
-	Value    interface{}
-	Label    interface{}
-	Selected bool
+	Value       interface{}
+	Label       interface{}
+	Selected    bool
+	Placeholder bool
 }
 
 func (s SelectOption) String() string {
@@ -21,6 +22,9 @@ func (s SelectOption) String() string {
 	bb.WriteString(`"`)
 	if s.Selected {
 		bb.WriteString(` selected`)
+	}
+	if s.Placeholder {
+		bb.WriteString(` hidden disabled`)
 	}
 	bb.WriteString(`>`)
 	bb.WriteString(l)

--- a/form/select_tag.go
+++ b/form/select_tag.go
@@ -99,7 +99,18 @@ func parseSelectOptions(opts tags.Options) SelectOptions {
 	sopts := opts["options"]
 	delete(opts, "options")
 
+	placeHolder := opts["placeholder"]
+	delete(opts, "placeholder")
+
 	so := SelectOptions{}
+	if ph, ok := placeHolder.(string); ok {
+		so = append(so, SelectOption{
+			Value:       "",
+			Label:       ph,
+			Placeholder: true,
+		})
+	}
+
 	if aw, ok := allowBlank.(bool); ok && aw {
 		so = append(so, SelectOption{
 			Value: "",
@@ -108,7 +119,7 @@ func parseSelectOptions(opts tags.Options) SelectOptions {
 	}
 
 	if x, ok := sopts.(SelectOptions); ok {
-		x = append(so, x...) // prepend blank SelectOption if present
+		x = append(so, x...) // prepend placerholder or blank SelectOption if present
 		return x
 	}
 

--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -104,6 +104,60 @@ func Test_SelectTag_WithMap_Selected(t *testing.T) {
 	r.Contains(s, `<option value="2">two</option>`)
 }
 
+func Test_SelectTag_WithMap_Selected_Withplaceholder(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"placeholder": "Select a country",
+		"options": []map[string]interface{}{
+			{"Colombia": "CO"},
+			{"France": "FR"},
+			{"United States": "US"},
+		},
+	})
+	s := st.String()
+	r.Contains(s, `<option value="" hidden disabled>Select a country</option>`)
+	r.Contains(s, `<option value="CO">Colombia</option>`)
+	r.Contains(s, `<option value="FR">France</option>`)
+	r.Contains(s, `<option value="US">United States</option>`)
+}
+
+func Test_SelectTag_WithMap_Selected_Withoutplaceholder(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"options": []map[string]interface{}{
+			{"Colombia": "CO"},
+			{"France": "FR"},
+			{"United States": "US"},
+		},
+	})
+	s := st.String()
+	r.NotContains(s, `<option value="" hidden disabled></option>`)
+	r.Contains(s, `<option value="CO">Colombia</option>`)
+	r.Contains(s, `<option value="FR">France</option>`)
+	r.Contains(s, `<option value="US">United States</option>`)
+}
+
+func Test_SelectTag_WithMap_Selected_Withplaceholder_Selected(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	st := f.SelectTag(tags.Options{
+		"placeholder": "Select a country",
+		"options": []map[string]interface{}{
+			{"Colombia": "CO"},
+			{"France": "FR"},
+			{"United States": "US"},
+		},
+		"value": "CO",
+	})
+	s := st.String()
+	r.Contains(s, `<option value="" hidden disabled>Select a country</option>`)
+	r.Contains(s, `<option value="CO" selected>Colombia</option>`)
+	r.Contains(s, `<option value="FR">France</option>`)
+	r.Contains(s, `<option value="US">United States</option>`)
+}
+
 func Test_SelectTag_WithSlice(t *testing.T) {
 	r := require.New(t)
 	f := form.New(tags.Options{})


### PR DESCRIPTION
Hello.
I made this PR because, on multiples time I encountered cases where I want a type of placeholder when using SelectTag, I found an option called "allow_blank" but this only creates an empty and selectable option tag.
So, taking "allow_blank" as a base I "implemented" a way to do what I really wanted...

By writing:
```
<% let countries = [{"Colombia":"CO"}, {"France":"FR"}] %>
<%= f.SelectTag("Country", {placeholder: "Select a Country", options: countries }) %>
```

You get:
```
<select class="form-control" id="Country" name="Country">
    <option value="" selected="" disabled="" hidden="">Select a Country</option>
    <option value="CO">Colombia</option>
    <option value="FR">France</option>
</select>
```

I chose "placeholder" because, that option on a select tag, do nothing, so is like a replacement.
I'll look forward your thinkings and opinions.