### PR TITLE
Ensure TextAreaTag content is properly encoded

### DIFF
--- a/form/select_tag_test.go
+++ b/form/select_tag_test.go
@@ -349,6 +349,17 @@ func Test_SelectTag_Multiple_SelectMultiple_Selectable_Interface(t *testing.T) {
 	r.Contains(s, `<option value="3">Mark</option>`)
 }
 
+func Test_SelectTagWithHTML(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	s := f.SelectTag(tags.Options{
+		"options": []map[string]interface{}{
+			{"<b>Not Bold</b>": "<u>Not Underlined</u>"},
+		},
+	})
+	r.Equal(`<select><option value="&lt;u&gt;Not Underlined&lt;/u&gt;">&lt;b&gt;Not Bold&lt;/b&gt;</option></select>`, s.String())
+}
+
 type SelectableModel struct {
 	Name string
 	ID   string

--- a/form/text_area_tag.go
+++ b/form/text_area_tag.go
@@ -12,7 +12,7 @@ func (f Form) TextArea(opts tags.Options) *tags.Tag {
 //TextAreaTag creates a textarea for a form with passed options
 func (f Form) TextAreaTag(opts tags.Options) *tags.Tag {
 	if opts["value"] != nil {
-		opts["body"] = opts["value"]
+		opts["encoded_body"] = opts["value"]
 		delete(opts, "value")
 	}
 

--- a/form/text_area_tag_test.go
+++ b/form/text_area_tag_test.go
@@ -37,6 +37,15 @@ func Test_Form_TextArea_nullsString_empty(t *testing.T) {
 	r.Equal(`<textarea></textarea>`, ta.String())
 }
 
+func Test_Form_TextArea_Escaped(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	ta := f.TextArea(tags.Options{
+		"value": "<b>This should not be bold</b>",
+	})
+	r.Equal(`<textarea>&lt;b&gt;This should not be bold&lt;/b&gt;</textarea>`, ta.String())
+}
+
 type nullString sql.NullString
 
 func (ns nullString) Value() (driver.Value, error) {


### PR DESCRIPTION
This commit ensures that the contents of a TextAreaTag are always encoded properly and adds test cases for both TextAreaTag and SelectTag.