### PR TITLE
Keep value from option map in CheckboxTag

### DIFF
--- a/form/checkbox_tag.go
+++ b/form/checkbox_tag.go
@@ -13,13 +13,18 @@ func (f Form) CheckboxTag(opts tags.Options) *tags.Tag {
 
 	value := opts["value"]
 	delete(opts, "value")
+	if value == nil || value == "" {
+		value = "true"
+	}
+	opts["value"] = value
 
 	checked := opts["checked"]
 	delete(opts, "checked")
-	if checked == nil {
+
+	isChecked := checked != nil
+	if !isChecked {
 		checked = "true"
 	}
-	opts["value"] = checked
 
 	unchecked := opts["unchecked"]
 	delete(opts, "unchecked")
@@ -30,13 +35,13 @@ func (f Form) CheckboxTag(opts tags.Options) *tags.Tag {
 	if opts["tag_only"] == true {
 		delete(opts, "label")
 		ct := f.InputTag(opts)
-		ct.Checked = template.HTMLEscaper(value) == template.HTMLEscaper(checked)
+		ct.Checked = isChecked && template.HTMLEscaper(value) == template.HTMLEscaper(checked)
 		return ct
 	}
 
 	tag := tags.New("label", tags.Options{})
 	ct := f.InputTag(opts)
-	ct.Checked = template.HTMLEscaper(value) == template.HTMLEscaper(checked)
+	ct.Checked = isChecked && template.HTMLEscaper(value) == template.HTMLEscaper(checked)
 	tag.Append(ct)
 
 	if opts["name"] != nil && unchecked != nil {

--- a/form/checkbox_tag_test.go
+++ b/form/checkbox_tag_test.go
@@ -46,3 +46,44 @@ func Test_Form_CheckboxTag_WithLabel(t *testing.T) {
 	})
 	r.Equal(`<label><input name="Chubby" type="checkbox" value="true" /> check me</label>`, ct.String())
 }
+
+func Test_Form_CheckboxTag_With_Text_Value(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	ct := f.CheckboxTag(tags.Options{
+		"value": "Custom Value",
+		"name":  "Chubby",
+	})
+	r.Equal(`<label><input name="Chubby" type="checkbox" value="Custom Value" /></label>`, ct.String())
+}
+
+func Test_Form_CheckboxTag_Tag_Only(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	ct := f.CheckboxTag(tags.Options{
+		"tag_only": true,
+		"name":     "Chubby",
+	})
+	r.Equal(`<input name="Chubby" type="checkbox" value="true" />`, ct.String())
+}
+
+func Test_Form_CheckboxTag_With_Empty_Text_Value(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	ct := f.CheckboxTag(tags.Options{
+		"value": "",
+		"name":  "Chubby",
+	})
+	r.Equal(`<label><input name="Chubby" type="checkbox" value="true" /></label>`, ct.String())
+}
+
+func Test_Form_CheckboxTag_TagOnly_With_CustomValue(t *testing.T) {
+	r := require.New(t)
+	f := form.New(tags.Options{})
+	ct := f.CheckboxTag(tags.Options{
+		"tag_only": true,
+		"value":    "Cutsom Value",
+		"name":     "Chubby",
+	})
+	r.Equal(`<input name="Chubby" type="checkbox" value="Cutsom Value" />`, ct.String())
+}


### PR DESCRIPTION
This PR fix the issue when you pass the `value` option with a custom value, it is always rendered with as `value="true"`

`<%= f.CheckboxTag({name: "UserType", value: "Client"}) %>`

Actual:
```
<label>
    <input class="" id="user-UserType" name="UserType" type="checkbox" value="true" />
</label>
```

Expected:
```
<label>
    <input class="" id="user-UserType" name="UserType" type="checkbox" value="Client" />
</label>
```
