### PR TITLE
Set a default value true and not checked when bool field is false

### DIFF
--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -334,3 +334,48 @@ func Test_Field_TagOnly(t *testing.T) {
 		})
 	}
 }
+
+func Test_Field_Boolean(t *testing.T) {
+	model := struct {
+		IsAdmin bool `schema:"-"`
+	}{}
+	cases := []struct {
+		f      func(field string, opt tags.Options) *tags.Tag
+		Value  bool
+		name   string
+		opts   tags.Options
+		output string
+	}{
+		{
+			Value: false,
+			name:  "IsAdmin",
+			opts: tags.Options{
+				"tag_only": true,
+				"class":    "custom-input",
+			},
+			output: `<input class="custom-input" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" />`,
+		},
+
+		{
+			Value: true,
+			name:  "IsAdmin",
+			opts: tags.Options{
+				"tag_only": true,
+				"class":    "custom-input",
+			},
+			output: `<input class="custom-input" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" checked />`,
+		},
+	}
+
+	for index, tcase := range cases {
+		t.Run(fmt.Sprintf("%v", index), func(tt *testing.T) {
+			r := require.New(tt)
+
+			model.IsAdmin = tcase.Value
+			f := bootstrap.NewFormFor(model, tags.Options{})
+
+			l := f.CheckboxTag(tcase.name, tcase.opts)
+			r.Equal(tcase.output, l.String())
+		})
+	}
+}

--- a/form/bootstrap/form_for_test.go
+++ b/form/bootstrap/form_for_test.go
@@ -355,7 +355,6 @@ func Test_Field_Boolean(t *testing.T) {
 			},
 			output: `<input class="custom-input" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" />`,
 		},
-
 		{
 			Value: true,
 			name:  "IsAdmin",
@@ -364,6 +363,26 @@ func Test_Field_Boolean(t *testing.T) {
 				"class":    "custom-input",
 			},
 			output: `<input class="custom-input" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" checked />`,
+		},
+		{
+			Value:  false,
+			name:   "IsAdmin",
+			opts:   tags.Options{},
+			output: `<div class="form-group"><label><input class="" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" /> IsAdmin</label></div>`,
+		},
+		{
+			Value:  true,
+			name:   "IsAdmin",
+			opts:   tags.Options{},
+			output: `<div class="form-group"><label><input class="" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" checked /> IsAdmin</label></div>`,
+		},
+		{
+			Value: false,
+			name:  "IsAdmin",
+			opts: tags.Options{
+				"unchecked": false,
+			},
+			output: `<div class="form-group"><label><input class="" id="-IsAdmin" name="IsAdmin" type="checkbox" value="true" /><input name="IsAdmin" type="hidden" value="false" /> IsAdmin</label></div>`,
 		},
 	}
 

--- a/form/form_for.go
+++ b/form/form_for.go
@@ -96,10 +96,10 @@ func (f FormFor) buildCheckboxOptions(field string, opts tags.Options) {
 	if fn.Kind() == reflect.Bool {
 		if ov == nil {
 			opts["value"] = true
+		}
 
-			if opts["checked"] == nil && !fn.Bool() {
-				opts["checked"] = fn.Bool()
-			}
+		if opts["checked"] == nil && !fn.Bool() {
+			opts["checked"] = fn.Bool()
 		}
 	}
 }


### PR DESCRIPTION
Fix when a model with `bool` field is false, actually is rendering a checkbox with `false` value.

To fix that, I update checkbogxtag from `form_for`, and set like:

```go
type User struct {
    IsAdmin bool `....`
}
```

In template:
```
<%= f.CheckboxTag("IsAdmin") %>
```

When `user.IsAdmin = false`:
```HTML
<div class="form-group">
    <label><input class="" id="user-IsAdmin" name="IsAdmin" type="checkbox" value="true" /> IsAdmin</label>
</div>
```

When `user.IsAdmin = true`:
```plush

<%= f.CheckboxTag("IsAdmin") %>

```

```HTML
<div class="form-group">
    <label><input class="" id="user-IsAdmin" name="IsAdmin" type="checkbox" value="true" checked /> IsAdmin</label>
</div>
```