### PR TITLE
Add Bootstrap 5 "form-label" class to generated form label.

### DIFF
--- a/form/bootstrap/common.go
+++ b/form/bootstrap/common.go
@@ -61,7 +61,8 @@ func divWrapper(opts tags.Options, fn func(opts tags.Options) tags.Body) *tags.T
 	useLabel := opts["hide_label"] == nil
 	if useLabel && opts["label"] != nil {
 		div.Prepend(tags.New("label", tags.Options{
-			"body": opts["label"],
+			"class": "form-label",
+			"body":  opts["label"],
 		}))
 		delete(opts, "label")
 	}


### PR DESCRIPTION
In Bootstrap 5 now the label must have the class `form-label` inside the `form-group` otherwise the spaces are not maintained correctly.